### PR TITLE
Add bootstrap formatting to beans index view.  Beans are displayed in…

### DIFF
--- a/app/views/beans/index.html.erb
+++ b/app/views/beans/index.html.erb
@@ -1,8 +1,23 @@
-<div>
+<!-- <div>
   <% @beans.each do |bean|%>
   <%= bean.title%>
   <%= bean.description%>
   <%= bean.price%>
   <%= bean.image%>
 <% end %>
+</div>
+
+ -->
+
+<div class='row'>
+  <% @beans.each do |bean| %>
+    <div class="col-md-4">
+      <img src='https://robohash.org/<%= bean.title %>'</img>
+      <h3><%= bean.title %></h3>
+      <p><%= bean.description %></p>
+      <p><%= bean.price %></p>
+      <p><%= bean.image %></p>
+    </div>
+  <% end %>
+
 </div>

--- a/spec/features/guest_visits_items_index_spec.rb
+++ b/spec/features/guest_visits_items_index_spec.rb
@@ -7,18 +7,22 @@ feature "Guest visits item index" do
 
     visit beans_path
 
-    expect(page).to have_content("Ethiopian Sidama")
-    expect(page).to have_content("Good coffee")
-    expect(page).to have_content(14)
-    expect(page).to have_content("test")
+    within(".row div:nth-child(1)") do
+      expect(page).to have_content("Ethiopian Sidama")
+      expect(page).to have_content("Good coffee")
+      expect(page).to have_content(14)
+      expect(page).to have_content("test")
 
-    expect(page).to have_content("Kenyan Thimu")
-    expect(page).to have_content("Great coffee")
-    expect(page).to have_content(15)
-    expect(page).to have_content("test")
+    end
+
+    within(".row div:nth-child(2)") do
+      expect(page).to have_content("Kenyan Thimu")
+      expect(page).to have_content("Great coffee")
+      expect(page).to have_content(15)
+      expect(page).to have_content("test")
+    end
 
     expect(Bean.count).to eq(2)
-
 
   end
 end


### PR DESCRIPTION
Add bootstrap formatting to beans index view.  Beans are displayed in columns of three with necessary attributes displayed.  Feature testing made more robust reference same.  Test all passing.  It's first pass formatting to get the testing more exact.  We'll do more in the next day.