### PR TITLE
Add link to bean show

### DIFF
--- a/app/views/beans/index.html.erb
+++ b/app/views/beans/index.html.erb
@@ -4,7 +4,7 @@
     <div class="thumbnail">
       <img src="..." alt="...">
       <div class="caption">
-        <h3>Name: <%= bean.title %></h3>
+        <h3><%= link_to bean.title, bean_path(bean) %></h3>
         <p>Description: <%= bean.description %></p>
         <p>Price: <%= bean.price %></p>
         <p>   <%= button_to "Add Item", cart_index_path(bean_id: bean.id),  class: "btn btn_danger"%></p>


### PR DESCRIPTION
On bean index page, the title of each bean has been changed to
be a link to that bean show page. Also removed 'name:' from
the cards on bean index page.