### PR TITLE
Add category validation and model test

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,7 @@
 class Category < ApplicationRecord
   extend FriendlyId
+  validates :name, presence: true, uniqueness: true
+
   before_create :slug
 
   friendly_id :name, use: :slugged

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
-RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Category, type: :model do
+  describe "validations" do
+    context "invalid attributes" do
+      it 'is invalid without a name' do
+        cat = Category.new(name: '')
+
+        expect(cat).to be_invalid
+      end
+
+      it 'is invalid without a uniqe name' do
+        Category.create(name: 'test')
+        cat = Category.create(name: 'test')
+
+        expect(cat).to be_invalid
+      end
+    end
+
+    context 'valid attributes' do
+      it 'is valid with a unique name' do
+        cat = Category.create(name: 'test')
+
+        expect(cat).to be_valid
+      end
+    end
+  describe 'relationships' do
+    it 'has many beans' do
+      cat = Category.create(name: 'test')
+      cat.beans.create(title: "Ethiopian Wazzala",
+                       description: "Light roasted Yirgacheffe",
+                       price: 17,
+                       image: "wazzala.jpg")
+      cat.beans.create(title: 'test',
+                       description: 'test',
+                       price: 12,
+                       image: 'test.jpg')
+      expect(cat).to respond_to(:beans)
+      expect(cat.beans.count).to eq 2
+    end
+  end
+end
 end


### PR DESCRIPTION
Adds validation of uniqueness and presence of
name to category model. Creates validation
testing for category. The relationship
between a category and its beans is also
tested. Test currently passing.