### PR TITLE
Add Dragonfly gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/system/dragonfly/**


### PR DESCRIPTION
adds public/system/dragonfly/** to gitignore
file.  This should save the large amount of
image files generated by the dragonfly gem
from bloating up our development and test
versions in github.